### PR TITLE
Allow to provide path to jamonapi.properties as context parameter with f...

### DIFF
--- a/jamon/src/main/java/com/jamonapi/JamonPropertiesLoader.java
+++ b/jamon/src/main/java/com/jamonapi/JamonPropertiesLoader.java
@@ -1,13 +1,20 @@
 package com.jamonapi;
 
-import com.jamonapi.utils.Misc;
-
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.util.ResourceUtils;
+
+import com.jamonapi.utils.Misc;
 
 /**
  * Load jamon properties.  The order of loading is to look in the file named jamonapi.properties in the classpath.
@@ -18,6 +25,7 @@ import java.util.Properties;
  * Created by stevesouza on 7/13/14.
  */
 public class JamonPropertiesLoader {
+	private static final Log LOGGER = LogFactory.getLog(JamonPropertiesLoader.class);
 
     private String fileName;
     private Properties jamonProps;
@@ -28,7 +36,7 @@ public class JamonPropertiesLoader {
         this("jamonapi.properties");
     }
 
-    JamonPropertiesLoader(String fileName) {
+    public JamonPropertiesLoader(String fileName) {
         this.fileName = fileName;
     }
 
@@ -39,6 +47,7 @@ public class JamonPropertiesLoader {
      */
     public Properties getJamonProperties() {
         if (jamonProps==null) {
+        	LOGGER.info("jamonProps are not assiged, call initialize.");
             initialize();
         }
         return jamonProps;
@@ -85,17 +94,46 @@ public class JamonPropertiesLoader {
 
 
     private  Properties propertyLoader(String fileName)  {
+    	
         Properties properties = new Properties();
         InputStream input = null;
-        try {
-            input = getClass().getClassLoader().getResourceAsStream(fileName);
-            if (input!=null) {
-                properties.load(input);
-            }
-        } catch (Throwable t) {
-            // want to ignore exception and proceed with loading with CLI props or defaults.
-        } finally{
-            close(input);
+        
+		if (ResourceUtils.isUrl(fileName)) {
+        
+	        try {
+	        	LOGGER.info("Try to load jamonapi properties from file location: " + fileName);
+	        	File file = ResourceUtils.getFile(fileName);
+	        	if (file.exists()) {
+	        		input = new FileInputStream(file);
+	        		properties.load(input);
+	            	LOGGER.info("Load jamonapi properties from file location passed: " + fileName);
+	        	}
+	        	else {
+	        		LOGGER.warn("The file was not found: " + fileName);
+	        		throw new FileNotFoundException();
+	        	}
+	        }
+	        catch (Exception ex) {
+	        	LOGGER.warn("Load jamonapi properties from file failed: " + fileName, ex);
+	        }
+	        finally {
+	        	close(input);
+	        }
+		}
+		
+        if (properties.isEmpty()) {
+        	LOGGER.info("Try to load the jamonapi properties from: " + fileName);
+        	
+	        try {
+	            input = getClass().getClassLoader().getResourceAsStream(fileName);
+	            if (input!=null) {
+	                properties.load(input);
+	            }
+	        } catch (Throwable t) {
+	            // want to ignore exception and proceed with loading with CLI props or defaults.
+	        } finally{
+	            close(input);
+	        }
         }
 
         return properties;

--- a/jamon/src/main/java/com/jamonapi/distributed/HazelcastFilePersister.java
+++ b/jamon/src/main/java/com/jamonapi/distributed/HazelcastFilePersister.java
@@ -1,5 +1,10 @@
 package com.jamonapi.distributed;
 
+import java.util.Properties;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 /**  Class that interacts with HazelCast to save jamon data to it so data from any jvm's in the hazelcast cluster
  * can be visible via the jamon web app.  Note in most cases hazelcast exceptions are not bubbled up in this class
  * as jamon should still be availalbe even if HazelCast has issues.  The exceptions and stack traces can be
@@ -9,9 +14,17 @@ package com.jamonapi.distributed;
  */
 
 public class HazelcastFilePersister extends HazelcastPersister {
+	private static final Log LOGGER = LogFactory.getLog(HazelcastFilePersister.class);
 
     public HazelcastFilePersister() {
         super(new HazelcastPersisterImp(), new LocalJamonFilePersister());
+
+        LOGGER.info("Created HazelcastFilePersister with default jamonProperties.");
     }
 
+    public HazelcastFilePersister(final Properties jamonProperties) {
+        super(new HazelcastPersisterImp(), new LocalJamonFilePersister(jamonProperties));
+        
+        LOGGER.info("Created HazelcastFilePersister with provided jamonProperties.");
+    }
 }

--- a/jamon/src/main/java/com/jamonapi/distributed/JamonDataPersisterFactory.java
+++ b/jamon/src/main/java/com/jamonapi/distributed/JamonDataPersisterFactory.java
@@ -1,8 +1,11 @@
 package com.jamonapi.distributed;
 
-import com.jamonapi.JamonPropertiesLoader;
-
 import java.util.Properties;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.jamonapi.JamonPropertiesLoader;
 
 /**
  * Class that instanciates the JamonDataPersister class.  Note this could be a local implementation or a distributed implementation
@@ -12,6 +15,8 @@ import java.util.Properties;
  * Created by stevesouza on 7/6/14.
  */
 public class JamonDataPersisterFactory {
+	
+	private static final Log LOGGER = LogFactory.getLog(JamonDataPersisterFactory.class);
 
     private static JamonDataPersisterFactory factory = new JamonDataPersisterFactory();
     private JamonDataPersister jamonDataPersister;
@@ -19,32 +24,58 @@ public class JamonDataPersisterFactory {
     private Properties jamonProperties;
 
     private JamonDataPersisterFactory() {
-        jamonProperties = new JamonPropertiesLoader().getJamonProperties();
-        jamonDataPersisterName = jamonProperties.getProperty("jamonDataPersister");
     }
 
     public static JamonDataPersister get() {
-        if (factory.jamonDataPersister ==null) {
+        if (factory.jamonDataPersister == null) {
             factory.initialize();
         }
          return factory.jamonDataPersister;
     }
 
     public static Properties getJamonProperties() {
+    	
+    	if (factory.jamonProperties == null) {
+    		LOGGER.info("The factory.jamonProperties are not assigned, create default properties.");
+    		factory.jamonProperties = new JamonPropertiesLoader().getJamonProperties();
+    	}
+    	
         return factory.jamonProperties;
+    }
+    
+    public static void setJamonProperties(final Properties jamonProperties) {
+    	LOGGER.info("Set the jamonProperties: " + jamonProperties);
+        factory.jamonProperties = jamonProperties;
     }
 
     // initialize with HazelCast implementation if you can.  If not use the local implementation.
     private void initialize() {
-        jamonDataPersister =  create(jamonDataPersisterName);
+    	if (jamonProperties == null) {
+    		LOGGER.info("Initialize: No jamonProperties available. Create default jamonProperties.");
+    		jamonProperties = new JamonPropertiesLoader().getJamonProperties();
+    	}
+
+    	jamonDataPersisterName = jamonProperties.getProperty("jamonDataPersister");
+    	
+		LOGGER.warn("Initialize: jamonDataPersister with className: " + jamonDataPersisterName);
+        jamonDataPersister =  create(jamonDataPersisterName, jamonProperties);
         if (jamonDataPersister ==null) {
-           jamonDataPersister = new LocalJamonFilePersister();
+           jamonDataPersister = new LocalJamonFilePersister(jamonProperties);
         }
     }
 
-    private static JamonDataPersister create(String className) {
+    private static JamonDataPersister create(String className, final Properties jamonProperties) {
         try {
-            return (JamonDataPersister) Class.forName(className).newInstance();
+        	JamonDataPersister instance = null;
+        	if (jamonProperties == null) {
+        		LOGGER.info("Create new instance of " + className + " without properties.");
+        		instance = (JamonDataPersister) Class.forName(className).newInstance();
+        	}
+        	else {
+        		LOGGER.info("Create new instance of " + className + " with provided properties.");
+        		instance = (JamonDataPersister) Class.forName(className).getDeclaredConstructor(Properties.class).newInstance(jamonProperties);
+        	}
+            return instance;
         } catch (Throwable e) {
         }
         return null;

--- a/jamon/src/main/java/com/jamonapi/distributed/JamonServletContextListener.java
+++ b/jamon/src/main/java/com/jamonapi/distributed/JamonServletContextListener.java
@@ -1,14 +1,19 @@
 package com.jamonapi.distributed;
 
-import com.jamonapi.JamonPropertiesLoader;
-import com.jamonapi.MonitorFactory;
-import com.jamonapi.jmx.JmxUtils;
-import com.jamonapi.utils.LocaleContext;
+import java.util.Properties;
+import java.util.Timer;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
-import java.util.Properties;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.jamonapi.JamonPropertiesLoader;
+import com.jamonapi.MonitorFactory;
+import com.jamonapi.jmx.JmxUtils;
+import com.jamonapi.utils.LocaleContext;
 
 /**
  * A timer is executed when the web container starts up.  The timer saves jamon data every N minutes per a config
@@ -17,49 +22,124 @@ import java.util.Properties;
  * Created by stevesouza on 7/6/14.
  */
 public class JamonServletContextListener implements ServletContextListener  {
+	
+	private static final Log LOGGER = LogFactory.getLog(JamonServletContextListener.class);
 
     private static final int MINUTES = 60*1000;
+    
+    private JamonDataPersisterTimerTask saveTask;
+    private Timer saveTimer;
+    
+    private JamonPropertiesLoader loader;
 
     //Run this before web application is started
     @Override
     public void contextInitialized(ServletContextEvent event) {
         ServletContext context = event.getServletContext();
         if (context != null) {
-            addListeners();
-            addJmxBeans();
-            JamonDataPersisterTimerTask saveTask = getDistributedJamonTimerTask();
-            int refreshRate = getRefreshRate();
-            saveTask.schedule(refreshRate);
+        	
+        	String jamonPropertiesLocation = context.getInitParameter("jamonPropertiesLocation");
+        	context.log("Initialize the JamonServletContextListener, jamonPropertiesLocation: " + jamonPropertiesLocation);
+
+        	LOGGER.info(">> Initialize the JamonServletContextListener, jamonPropertiesLocation: " + jamonPropertiesLocation);
+        	
+        	if (jamonPropertiesLocation != null) {
+        		loader = new JamonPropertiesLoader(jamonPropertiesLocation);
+        		// load the properties
+        		Properties props = loader.getJamonProperties();
+        		
+        		LOGGER.info("Loaded jamonapi properties: " + props);
+        	}
+        	else {
+        		LOGGER.info("Use default jamonapi properties loader.");
+            	loader = new JamonPropertiesLoader();
+        	}
+        	
+            addListeners(loader);
+            addJmxBeans(loader);
+            
+            context.log("Prepare the saveTask.");
+            LOGGER.info("Prepare the saveTask.");
+            saveTask = getDistributedJamonTimerTask(loader);
+            int refreshRate = getRefreshRate(loader);
+            saveTimer = saveTask.schedule(refreshRate);
         }
     }
-
-    private void addListeners() {
-        JamonPropertiesLoader loader = new JamonPropertiesLoader();
+    
+    private void addListeners(JamonPropertiesLoader loader) {
         MonitorFactory.addListeners(loader.getListeners());
     }
 
-    private void addJmxBeans() {
-       JmxUtils.registerMbeans();
+    private void addJmxBeans(JamonPropertiesLoader loader) {
+       JmxUtils.registerMbeans(loader);
     }
 
-    JamonDataPersisterTimerTask getDistributedJamonTimerTask() {
-        return new JamonDataPersisterTimerTask(getJamonData());
+    JamonDataPersisterTimerTask getDistributedJamonTimerTask(final JamonPropertiesLoader loader) {
+    	LOGGER.info("Create the JamonDataPersisterTimerTask.");
+        return new JamonDataPersisterTimerTask(getJamonData(loader));
     }
 
-    JamonDataPersister getJamonData() {
+    JamonDataPersister getJamonData(final JamonPropertiesLoader loader) {
+    	// set the properties
+    	JamonDataPersisterFactory.setJamonProperties(loader.getJamonProperties());
+    	
         return JamonDataPersisterFactory.get();
     }
 
 
-    int getRefreshRate() {
-        Properties properties = new JamonPropertiesLoader().getJamonProperties();
+    int getRefreshRate(JamonPropertiesLoader loader) {
+        Properties properties = loader.getJamonProperties();
         return MINUTES * Integer.valueOf(properties.getProperty("distributedDataRefreshRateInMinutes"));
     }
 
     @Override
     public void contextDestroyed(ServletContextEvent event)  {
+		ServletContext context = event.getServletContext();
+        if (context != null) {
+        	context.log("The context is destroyed.");
+        }
+
+    	if (saveTimer != null) {
+            if (context != null) {
+            	context.log("The context is destroyed, stop the saveTimer: " + saveTimer);
+            }
+    		try {
+    			saveTimer.cancel();
+    		}
+    		catch (Exception ex) {
+    			LOGGER.warn("Stop save timer failed.", ex);
+                if (context != null) {
+                	context.log("The context is destroyed but stop the saveTimer failed.", ex);
+                }
+    		}
+    	}
+    	else {
+            if (context != null) {
+            	context.log("The context is destroyed, no saveTimer to stop available.");
+            }
+    	}
+        
+    	if (saveTask != null) {
+            if (context != null) {
+            	context.log("The context is destroyed, stop the saveTask: " + saveTask);
+            }
+    		try {
+    			saveTask.cancel();
+    		}
+    		catch (Exception ex) {
+    			LOGGER.warn("Stop save task failed.", ex);
+                if (context != null) {
+                	context.log("The context is destroyed but stop the saveTask failed.", ex);
+                }
+    		}
+    	}
+    	else {
+            if (context != null) {
+            	context.log("The context is destroyed, no saveTask to stop available.");
+            }
+    	}
         LocaleContext.reset();
-        JmxUtils.unregisterMbeans();
+        JmxUtils.unregisterMbeans(loader);
     }
 
 }

--- a/jamon/src/main/java/com/jamonapi/distributed/LocalJamonFilePersister.java
+++ b/jamon/src/main/java/com/jamonapi/distributed/LocalJamonFilePersister.java
@@ -1,28 +1,47 @@
 package com.jamonapi.distributed;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import com.jamonapi.JamonPropertiesLoader;
 import com.jamonapi.MonitorComposite;
 import com.jamonapi.MonitorFactory;
 import com.jamonapi.utils.FileUtils;
 import com.jamonapi.utils.SerializationUtils;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-
 /** Persist/serialize jamon data (MonitorComposite) to a local file.
  *
  * Created by stevesouza on 8/10/14.
  */
 public class LocalJamonFilePersister extends LocalJamonDataPersister {
+	
+	private static final Log LOGGER = LogFactory.getLog(LocalJamonFilePersister.class);
+	
     private static final String FILE_EXT = ".ser";
-    private JamonPropertiesLoader jamonPropertiesLoader = new JamonPropertiesLoader();
+    private Properties jamonProperties;
     private Map<String, String> fileNameMap=new HashMap<String, String>();
     static final String JAMON_FILE_NAME = INSTANCE+"-saved";
 
+    public LocalJamonFilePersister(final Properties jamonProperties) {
+    	this.jamonProperties = jamonProperties;
+    	
+    	LOGGER.info("Create LocalJamonFilePersister with jamonProperties: " + jamonProperties);
+    }
+
+    public LocalJamonFilePersister() {
+    	this(new JamonPropertiesLoader().getJamonProperties());
+
+    	LOGGER.warn("Created LocalJamonFilePersister with default properties.");
+    }
+    
     /** Get instances by looking in directory for any saved files and also add local in memory instance */
     @Override
     public Set<String> getInstances() {
@@ -97,7 +116,7 @@ public class LocalJamonFilePersister extends LocalJamonDataPersister {
      * @return  Directory where jamon data is stored
      */
     protected String getDirectoryName() {
-        String rootDir  = jamonPropertiesLoader.getJamonProperties().getProperty("jamonDataPersister.directory");
+        String rootDir  = jamonProperties.getProperty("jamonDataPersister.directory");
         if (rootDir.endsWith(File.separator)) {
           return rootDir;
         }

--- a/jamon/src/main/java/com/jamonapi/jmx/JmxUtils.java
+++ b/jamon/src/main/java/com/jamonapi/jmx/JmxUtils.java
@@ -155,14 +155,14 @@ import java.util.*;
     /**
      *  register all jamon related mbeans
      */
-    public static  void registerMbeans() {
-        registerMbeans(ManagementFactory.getPlatformMBeanServer());
+    public static  void registerMbeans(final JamonPropertiesLoader loader) {
+        registerMbeans(ManagementFactory.getPlatformMBeanServer(), loader);
     }
 
      /**
      *  Register all jamon related mbeans with the passed in MBeanServer
      */
-    public static  void registerMbeans(MBeanServer mBeanServer) {
+    public static  void registerMbeans(MBeanServer mBeanServer, final JamonPropertiesLoader loader) {
         try {
             mBeanServer.registerMBean(new Log4jMXBeanImp(), Log4jMXBeanImp.getObjectName());
             mBeanServer.registerMBean(new ExceptionMXBeanImp(), ExceptionMXBeanImp.getObjectName());
@@ -174,7 +174,7 @@ import java.util.*;
 
             // gcMXBean gets notifications from gc events and saves results in jamon.
             registerGcMXBean(mBeanServer);
-            registerMbeansFromPropsFile(mBeanServer);
+            registerMbeansFromPropsFile(mBeanServer, loader);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -185,8 +185,7 @@ import java.util.*;
      * If there are no configurable monitors taken from the file then a set of default
      * ones will be created (pageHits, sql).
      */
-    private static  void registerMbeansFromPropsFile(MBeanServer mBeanServer) throws Exception {
-        JamonPropertiesLoader loader = new JamonPropertiesLoader();
+    private static  void registerMbeansFromPropsFile(MBeanServer mBeanServer, final JamonPropertiesLoader loader) throws Exception {
         List<String> jamonJmxBeanProperties = loader.getMxBeans();
         Iterator<String> iter = jamonJmxBeanProperties.iterator();
 
@@ -206,15 +205,15 @@ import java.util.*;
     /**
      * unRegister all jamon related mbeans
      */
-    public static void unregisterMbeans() {
-        unregisterMbeans(ManagementFactory.getPlatformMBeanServer());
+    public static void unregisterMbeans(final JamonPropertiesLoader loader) {
+        unregisterMbeans(ManagementFactory.getPlatformMBeanServer(), loader);
     }
 
 
     /**
      * unRegister all jamon related mbeans
      */
-    public static void unregisterMbeans(MBeanServer mBeanServer) {
+    public static void unregisterMbeans(MBeanServer mBeanServer, final JamonPropertiesLoader loader) {
         try {
             mBeanServer.unregisterMBean(Log4jMXBeanImp.getObjectName());
             mBeanServer.unregisterMBean(ExceptionMXBeanImp.getObjectName());
@@ -224,7 +223,7 @@ import java.util.*;
             mBeanServer.unregisterMBean(HttpStatusMXBeanImp.getObjectName());
             mBeanServer.unregisterMBean(HttpStatusDeltaMXBeanImp.getObjectName());
             unregisterGcMXBean(mBeanServer);
-            unregisterMbeansFromPropsFile(mBeanServer);
+            unregisterMbeansFromPropsFile(mBeanServer, loader);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -237,8 +236,7 @@ import java.util.*;
      * @param mBeanServer
      * @throws Exception
      */
-    private static  void unregisterMbeansFromPropsFile(MBeanServer mBeanServer) throws Exception {
-        JamonPropertiesLoader loader = new JamonPropertiesLoader();
+    private static void unregisterMbeansFromPropsFile(MBeanServer mBeanServer, final JamonPropertiesLoader loader) throws Exception {
         List<String> jamonJmxBeanProperties = loader.getMxBeans();
         Iterator<String> iter = jamonJmxBeanProperties.iterator();
 

--- a/jamon/src/main/java/com/jamonapi/utils/Misc.java
+++ b/jamon/src/main/java/com/jamonapi/utils/Misc.java
@@ -171,7 +171,7 @@ public class Misc {
     /** Formats the passed in date with the passed in date format String.  See the main method for
      * sample Formats.  */
     public static String getFormattedDate(String format, Date date) {
-        return new SimpleDateFormat(format).format(date);    // 02
+        return new SimpleDateFormat(format, Locale.ENGLISH).format(date);    // 02
     }
 
     private static Format monthFormat=new SimpleDateFormat("MM");


### PR DESCRIPTION
...allback to default jamonapi.properties.

<context-param>
   <param-name>jamonPropertiesLocation</param-name>
   <param-value>file:${my-application.dir}/jamonapi.properties</param-value>
</context-param>
- Fixed Misc.getFormattedDate() to pass on non-english locales.
- Stop the saveTimer when the context is destroyed to prevent resource leak.

This is the replacement for https://github.com/stevensouza/jamonapi/pull/1
There might be easier ways to achieve the goal.
